### PR TITLE
Fix/instance explorer stale state

### DIFF
--- a/client/packages/big-instance-explorer/src/env/browser/generate-dialog.component.tsx
+++ b/client/packages/big-instance-explorer/src/env/browser/generate-dialog.component.tsx
@@ -297,22 +297,38 @@ export function GenerateDialog(props: GenerateDialogProps): ReactElement {
                     <div>
                         {props.preview.instanceCount} instance(s), {props.preview.slotCount} slot(s), {props.preview.linkCount} link(s).
                     </div>
-                    {props.preview.sample.length > 0 ? (
-                        <div style={sampleListStyle}>
-                            {props.preview.sample.map((instance, index) => (
-                                <div key={`${instance.name}-${index}`} style={sampleInstanceStyle}>
-                                    <div style={sampleHeaderStyle}>
-                                        {instance.name} : {instance.classifierName}
-                                    </div>
-                                    {instance.slots.map((slot, slotIndex) => (
-                                        <div key={`${slot.feature}-${slotIndex}`} style={sampleSlotStyle}>
-                                            {slot.feature} = {slot.value}
-                                        </div>
-                                    ))}
-                                </div>
-                            ))}
+                    {props.preview.perClassifier.length > 0 ? (
+                        <div style={hintStyle}>
+                            {props.preview.perClassifier.map(entry => `${entry.classifierName}: ${entry.instanceCount}`).join(' · ')}
                         </div>
                     ) : null}
+                    {props.preview.sample.length > 0
+                        ? props.preview.perClassifier
+                              .map(entry => ({
+                                  entry,
+                                  samples: props.preview!.sample.filter(instance => instance.classifierName === entry.classifierName)
+                              }))
+                              .filter(group => group.samples.length > 0)
+                              .map(group => (
+                                  <div key={group.entry.classifierName} style={sampleListStyle}>
+                                      <div style={hintStyle}>
+                                          {group.entry.classifierName} — showing {group.samples.length} of {group.entry.instanceCount}
+                                      </div>
+                                      {group.samples.map((instance, index) => (
+                                          <div key={`${instance.name}-${index}`} style={sampleInstanceStyle}>
+                                              <div style={sampleHeaderStyle}>
+                                                  {instance.name} : {instance.classifierName}
+                                              </div>
+                                              {instance.slots.map((slot, slotIndex) => (
+                                                  <div key={`${slot.feature}-${slotIndex}`} style={sampleSlotStyle}>
+                                                      {slot.feature} = {slot.value}
+                                                  </div>
+                                              ))}
+                                          </div>
+                                      ))}
+                                  </div>
+                              ))
+                        : null}
                     {props.preview.diagnostics.length > 0 ? (
                         <ul style={diagnosticsListStyle}>
                             {props.preview.diagnostics.map((diagnostic, index) => (

--- a/client/packages/big-instance-explorer/src/env/browser/instance-explorer.component.tsx
+++ b/client/packages/big-instance-explorer/src/env/browser/instance-explorer.component.tsx
@@ -142,6 +142,13 @@ export function InstanceExplorer(): ReactElement {
             setUnclassified(action.unclassified);
             setManyToManyRelations(action.manyToManyRelations ?? []);
             setAvailableForInstantiation(action.availableForInstantiation ?? { classifiers: [], associations: [] });
+            // The diagram/model just changed (e.g. a different .uml was opened): drop transient state
+            // that referenced the previous diagram so nothing stale is shown. The generatable
+            // classifiers are refreshed by the provider (see requestData), so they replace themselves.
+            setGeneratePreview(undefined);
+            setEditState(undefined);
+            setLinkEditState(undefined);
+            setSelectedInstanceId(undefined);
         });
     }, [listenAction]);
 

--- a/client/packages/big-instance-explorer/src/env/common/generate.action.ts
+++ b/client/packages/big-instance-explorer/src/env/common/generate.action.ts
@@ -52,12 +52,20 @@ export interface PreviewInstanceSample {
     slots: PreviewSlotSample[];
 }
 
+/** Complete per-classifier instance count (always full, even when the sample is truncated). */
+export interface PreviewClassifierCount {
+    classifierName: string;
+    instanceCount: number;
+}
+
 export interface GenerationResultSummary {
     instanceCount: number;
     slotCount: number;
     linkCount: number;
     diagnostics: GenerationDiagnosticSummary[];
-    /** Dry-run sample of the instances that would be created (preview). */
+    /** Complete count of instances per classifier (the authoritative "what will be created"). */
+    perClassifier: PreviewClassifierCount[];
+    /** Dry-run **sample** of the instances that would be created — stratified (a few per classifier), truncated. */
     sample: PreviewInstanceSample[];
 }
 
@@ -194,7 +202,7 @@ export namespace GenerateInstancesPreviewResponse {
         return {
             kind: KIND,
             responseId: options?.responseId ?? '',
-            summary: options?.summary ?? { instanceCount: 0, slotCount: 0, linkCount: 0, diagnostics: [], sample: [] }
+            summary: options?.summary ?? { instanceCount: 0, slotCount: 0, linkCount: 0, diagnostics: [], perClassifier: [], sample: [] }
         };
     }
 }

--- a/client/packages/big-instance-explorer/src/env/glsp-server/generate.core.ts
+++ b/client/packages/big-instance-explorer/src/env/glsp-server/generate.core.ts
@@ -112,14 +112,24 @@ export interface PreviewInstanceSample {
 }
 
 /**
- * Builds a human-readable sample (up to `limit` instances) from a generation patch,
- * for the dry-run preview. Reads the instance add operations produced by
- * {@link buildGeneration} without touching the model.
+ * Builds a human-readable, **stratified** sample for the dry-run preview: up to
+ * `perClassifierLimit` instances *per classifier* (so every selected/expanded classifier is
+ * represented, not just the first one), bounded by `maxTotal` overall. Reads the instance add
+ * operations produced by {@link buildGeneration} without touching the model.
+ *
+ * Rationale: a flat "first N" sample is biased toward whichever classifier was generated first;
+ * stratified sampling reflects all groups while staying small relative to the whole. The complete
+ * counts are reported separately (see the handler's summary), so the sample is illustrative only.
  */
-export function extractPreviewSample(patch: readonly PatchOperation[], limit: number): PreviewInstanceSample[] {
+export function extractPreviewSample(
+    patch: readonly PatchOperation[],
+    perClassifierLimit: number,
+    maxTotal: number
+): PreviewInstanceSample[] {
     const samples: PreviewInstanceSample[] = [];
+    const perClassifierCount = new Map<string, number>();
     for (const operation of patch) {
-        if (samples.length >= limit) {
+        if (samples.length >= maxTotal) {
             break;
         }
         if (operation.path !== '/diagram/entities/-') {
@@ -130,9 +140,15 @@ export function extractPreviewSample(patch: readonly PatchOperation[], limit: nu
             classifier?: { $refText?: string };
             slots?: { name?: string; values?: { value?: string }[] }[];
         };
+        const classifierName = instance.classifier?.$refText ?? '';
+        const used = perClassifierCount.get(classifierName) ?? 0;
+        if (used >= perClassifierLimit) {
+            continue;
+        }
+        perClassifierCount.set(classifierName, used + 1);
         samples.push({
             name: instance.name ?? '',
-            classifierName: instance.classifier?.$refText ?? '',
+            classifierName,
             slots: (instance.slots ?? []).map(slot => ({
                 feature: slot.name ?? '',
                 value: (slot.values ?? []).map(literal => literal.value ?? '').join(', ')

--- a/client/packages/big-instance-explorer/src/env/glsp-server/generate.handler.ts
+++ b/client/packages/big-instance-explorer/src/env/glsp-server/generate.handler.ts
@@ -365,15 +365,24 @@ function run(config: GenerationConfig, modelState: DiagramModelState): RunResult
     return { result, links };
 }
 
-const PREVIEW_SAMPLE_LIMIT = 10;
+/** Preview sample bounds: a few per classifier (so every classifier shows), capped overall. */
+const PREVIEW_SAMPLE_PER_CLASSIFIER = 5;
+const PREVIEW_SAMPLE_MAX_TOTAL = 25;
 
 function summarize({ result, links }: RunResult): GenerationResultSummary {
+    // Complete per-classifier counts (authoritative), preserving generation order.
+    const perClassifierCounts = new Map<string, number>();
+    for (const instance of result.instances) {
+        perClassifierCounts.set(instance.classifierName, (perClassifierCounts.get(instance.classifierName) ?? 0) + 1);
+    }
+
     return {
         instanceCount: result.instances.length,
         slotCount: result.instances.reduce((sum, instance) => sum + instance.slotCount, 0),
         linkCount: links.links.length,
         diagnostics: [...result.diagnostics, ...links.diagnostics].map(d => ({ code: d.code, severity: d.severity, message: d.message })),
-        sample: extractPreviewSample(result.patch, PREVIEW_SAMPLE_LIMIT)
+        perClassifier: [...perClassifierCounts].map(([classifierName, instanceCount]) => ({ classifierName, instanceCount })),
+        sample: extractPreviewSample(result.patch, PREVIEW_SAMPLE_PER_CLASSIFIER, PREVIEW_SAMPLE_MAX_TOTAL)
     };
 }
 

--- a/client/packages/big-instance-explorer/src/env/vscode/instance-explorer.webview-view-provider.ts
+++ b/client/packages/big-instance-explorer/src/env/vscode/instance-explorer.webview-view-provider.ts
@@ -26,6 +26,7 @@ import {
     GeneratableClassifiersResponse,
     GenerateInstancesPreviewResponse,
     InstanceExplorerDataResponse,
+    RequestGeneratableClassifiersAction,
     RequestInstanceExplorerDataAction,
     SaveExportedInstancesResponse
 } from '../common/index.js';
@@ -107,6 +108,10 @@ export class InstanceExplorerWebviewViewProvider extends WebviewViewProvider {
 
     protected requestData(): void {
         this.actionDispatcher.dispatch(RequestInstanceExplorerDataAction.create());
+        // Refresh the generatable classifiers/associations too, so the "Generate Test Data" dialog
+        // always reflects the active diagram (and any class-diagram edits) instead of a cached/stale
+        // set from a previously opened model.
+        this.actionDispatcher.dispatch(RequestGeneratableClassifiersAction.create());
     }
 
     protected dispatchSelectionChange(): void {

--- a/client/packages/big-instance-explorer/test/generate.core.test.ts
+++ b/client/packages/big-instance-explorer/test/generate.core.test.ts
@@ -259,7 +259,7 @@ describe('extractPreviewSample', () => {
     it('summarizes generated instances into name/classifier/slot values', () => {
         const person = classifier({ name: 'Person', properties: [pv('name'), pv('age', { typeKind: 'integer' })] });
         const result = buildGeneration([person], { count: 1, strategy: constStrategy('X'), idFactory: counter() });
-        const sample = extractPreviewSample(result.patch, 10);
+        const sample = extractPreviewSample(result.patch, 5, 25);
         assert.equal(sample.length, 1);
         assert.equal(sample[0].classifierName, 'Person');
         assert.match(sample[0].name, /person_/);
@@ -272,17 +272,34 @@ describe('extractPreviewSample', () => {
         );
     });
 
-    it('respects the limit', () => {
+    it('respects the per-classifier limit', () => {
         const person = classifier({ name: 'Person', properties: [pv('name')] });
         const result = buildGeneration([person], { count: 5, strategy: new RandomStrategy(), seed: 1, idFactory: counter() });
-        assert.equal(extractPreviewSample(result.patch, 2).length, 2);
+        assert.equal(extractPreviewSample(result.patch, 2, 25).length, 2);
+    });
+
+    it('samples each classifier (stratified), not just the first', () => {
+        const person = classifier({ name: 'Person', properties: [pv('name')] });
+        const address = classifier({ name: 'Address', properties: [pv('city')] });
+        // 10 of each; a flat "first 10" would show only Person — stratified must include both.
+        const result = buildGeneration([person, address], { count: 10, strategy: new RandomStrategy(), seed: 1, idFactory: counter() });
+        const sample = extractPreviewSample(result.patch, 3, 25);
+        assert.equal(sample.filter(s => s.classifierName === 'Person').length, 3);
+        assert.equal(sample.filter(s => s.classifierName === 'Address').length, 3);
+    });
+
+    it('caps the total sample size across classifiers', () => {
+        const classifiers = ['A1', 'B2', 'C3', 'D4'].map(name => classifier({ name, properties: [pv('p')] }));
+        const result = buildGeneration(classifiers, { count: 10, strategy: new RandomStrategy(), seed: 1, idFactory: counter() });
+        // 4 classifiers × up to 5 = 20, but capped at 14 overall.
+        assert.equal(extractPreviewSample(result.patch, 5, 14).length, 14);
     });
 
     it('joins multi-valued slots with a comma in the preview', () => {
         let n = 0;
         const seq: ValueStrategy = { kind: 'seq', value: () => `v${++n}` };
         const doc = classifier({ name: 'Doc', properties: [pv('lines', { lowerBound: 2, upperBound: 2 })] });
-        const sample = extractPreviewSample(buildGeneration([doc], { count: 1, strategy: seq, idFactory: counter() }).patch, 10);
+        const sample = extractPreviewSample(buildGeneration([doc], { count: 1, strategy: seq, idFactory: counter() }).patch, 5, 25);
         assert.equal(sample[0].slots[0].value, 'v1, v2');
     });
 });


### PR DESCRIPTION
Fixes the bugs:

- Preview is limited to 10 entries. when I want to generate a preview for 10 entries from 2 different classifiers I only see the 10 entries from classifier 1 as a preview. 

- When I open a new uml diagram the instance explorer already shows the new instances. when I click "Generate Test Data" there are still the old classifiers for selection available and not the classifiers from the new diagram.