### PR TITLE
fix(object-to-class): dispose listenAction listener on cleanup

### DIFF
--- a/client/packages/big-components/src/env/browser/vscode/vscode-context.ts
+++ b/client/packages/big-components/src/env/browser/vscode/vscode-context.ts
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: MIT
  **********************************************************************************/
 
-import type { Action } from '@eclipse-glsp/protocol';
+import type { Action, Disposable } from '@eclipse-glsp/protocol';
 import { createContext } from 'react';
 import type { NotificationHandler, NotificationType } from 'vscode-messenger-common';
 
@@ -29,8 +29,9 @@ export interface VSCodeContext {
     dispatchNotification: <P>(type: NotificationType<P>, params?: P) => void;
     /**
      * Listen for an action notification.
+     * Returns a Disposable that should be called when the listener is no longer needed.
      */
-    listenAction: (handler: (action: Action) => void) => void;
+    listenAction: (handler: (action: Action) => void) => Disposable;
     /**
      * Dispatch an action notification.
      * The client id will be automatically added to the action.

--- a/client/packages/big-object-to-class/src/env/browser/transformation-preview.component.tsx
+++ b/client/packages/big-object-to-class/src/env/browser/transformation-preview.component.tsx
@@ -43,7 +43,7 @@ export function TransformationPreview(): ReactElement {
 
     // 2. Listen for the backend results
     useEffect(() => {
-        listenAction(action => {
+        const disposable = listenAction(action => {
             // Debug: log incoming actions for preview troubleshooting
             console.debug('[Webview] received action', action);
             if (TransformationPreviewResponse.is(action)) {
@@ -66,7 +66,7 @@ export function TransformationPreview(): ReactElement {
                 setMessage(action.success ? "Successfully applied patches!" : "Error applying patches.");
             }
         });
-        return undefined;
+        return () => disposable.dispose();
     }, [listenAction]);
 
     // 3. Trigger Transformation


### PR DESCRIPTION
The useEffect in TransformationPreview called listenAction() but discarded the returned Disposable, leaking the listener on every re-render. This caused the UI to get stuck on loading because stale listeners accumulated and setIsLoading(false) was never reliably called.

Also fixes the listenAction type signature in VSCodeContext from void to Disposable to match the actual implementation.